### PR TITLE
4.5 Offsets & Patch rewrites

### DIFF
--- a/Epatches/misc.xml
+++ b/Epatches/misc.xml
@@ -3,11 +3,11 @@
 
 	<!-- All addreses are 1.08 unless stated otherwise -->		
 	
-	<Patch name="PatchGameVersionString" type="hook" search_start="0x4F7D65" comment="signature 1.16" >
+	<Patch name="PatchGameVersionString" type="hook" search_start="0x4F7D65" comment="signature 1.24.03" >
 		<Instruction code="4C 8D 05 XX XX XX XX" comment="lea r8, '%ls'; comment=version_string" />
 		<Instruction code="E8 XX XX XX XX" />
 		<Instruction code="4C 8B C3" comment="mov r8, rbx" />
-		<Instruction code="BA 04 00 00 00" comment="mov edx, 4" />
+		<Instruction code="BA 05 00 00 00" comment="mov edx, 5" />
 		<Instruction code="48 8B CF" comment="mov rcx, rdi" />
 		<Instruction code="E8 XX XX XX XX" comment="call send_method" />
 		
@@ -200,7 +200,7 @@
 	<!-- This patch is used by more than one functionality -->
 	<!-- This will also be called from derived class for ohzaru mob -->
 	<!-- This patch will break in almost every update *sigh* -->
-	<Patch name="PatchMobDtor" type="hook" search_start="0xB5F80" comment="signature based on 1.23" >
+	<Patch name="PatchMobDtor" type="hook" search_start="0xB5F80" comment="signature based on 1.24.03" >
 		<Instruction code="40 57" comment="push rdi" />
 		<Instruction code="48 83 EC 30" comment="sub rsp, 30h" />
 		<Instruction code="48 C7 44 24 20 FE FF FF  FF" comment="mov qword ptr[rsp+20h], -2" />
@@ -210,7 +210,7 @@
 		<Instruction code="48 89 01" comment="mov [rcx], rax" />
 		<Instruction code="E8 XXXXXXXX" comment="call XXXXXXXX" />
 		<Instruction code="90" comment="nop" />
-		<Instruction code="4C 8B 87 20 3C 00 00" comment="mov r8, [rdi+3C20h]" />
+		<Instruction code="4C 8B 87 38 3C 00 00" comment="mov r8, [rdi+3C38h]" />
 		
 		<Hook value="MobDtorPatched" setup="SetupMobDtor" />
 	</Patch>

--- a/Epatches/prebaked_patches.xml
+++ b/Epatches/prebaked_patches.xml
@@ -263,11 +263,11 @@
 		<Hook value="CusAuraPatchInt3" />
 	</Patch> -->	
 	
-	<!-- Signature is 1.21 -->
+	<!-- Signature is 1.24.03 -->
 	<Patch name="CusAuraPatchTeleport" type="notify" search_start="0xB5892" comment="This patch is very sensitive and candidate to be broken on game update. Patch implementation in the dll is also very sensitive to changes." >
 		<Instruction code="39 83 XXXXXXXX" comment="cmp [rbx+XXXXh], eax" />
 		<Instruction code="74 0A" comment="je teleport" />
-		<Instruction code="E9 8C 09 00 00" comment="jmp no_teleport" />
+		<Instruction code="E9 7C 09 00 00" comment="jmp no_teleport" />
 		<Instruction code="48 8B 74 24 48" comment="mov rsi, [rsp+48h]" />
 		<Instruction code="41 0F BA E7 09" comment="bt r15d, 9" />
 	
@@ -425,10 +425,10 @@
 	
 	<!-- This patch may break in the dll on any change. -->
 	<!-- When the patch breaks, implementation of default values of aur_bpe_map in PreBakeSetup must be reviewed. Also implementation of Xenoverse2::GetAuraExtra may need update. -->
-	<!-- Signature 1.23 -->
+	<!-- Signature 1.24.03 -->
 	<Patch name="PatchAurBpe" type="notify" search_start="0xF8BF6" >
 		<Instruction code="8D 42 E6" comment="lea eax, [rdx-1Ah]" />
-		<Instruction code="83 F8 22" comment="cmp eax, 22" />
+		<Instruction code="83 F8 23" comment="cmp eax, 23" />
 		<Instruction code="0F 87 XXXXXXXX" comment="ja default_case" />
 				
 		<Notify inst_index="2" value="AurToBpePatch" />
@@ -601,12 +601,12 @@
 		<Notify value="NULL" />
 	</Patch>
 	
-	<!--Signature 1.23 -->
-	<!-- If 0x2248 changes, relocate BattleMob::current_partset in game_defs.h. Hint: it is very likely that this var will be located at -4 from trans_control -->
+	<!--Signature 1.24.03 -->
+	<!-- If 0x2258 changes, relocate BattleMob::current_partset in game_defs.h. Hint: it is very likely that this var will be located at -4 from trans_control -->
 	<Patch name="ProtectTransPartset" type="notify" search_start="0xC00CC" >
 		<Instruction code="0F 57 C9" comment="xorps xmm1, xmm1" />
 		<Instruction code="FF 90 50 01 00 00" comment="call qword ptr [rax+150h]" />
-		<Instruction code="89 BB 48 22 00 00" comment="mov [rbx+2248h], edi" />		
+		<Instruction code="89 BB 58 22 00 00" comment="mov [rbx+2258h], edi" />		
 		
 		<Notify value="NULL" />
 	</Patch>

--- a/chara_patch.cpp
+++ b/chara_patch.cpp
@@ -1037,6 +1037,7 @@ PUBLIC void PreBakeSetup(size_t)
 	cus_aura_lookup[32] = 0x3A;
 	cus_aura_lookup[33] = 0x3B;
 	cus_aura_lookup[34] = 0x3C;
+	cus_aura_lookup[35] = 0x3D;
 	// Original behaviour_11 values: nothing (the 0xFF init will ensure that)
 	// Original int 2 values (only non zero)
 	cus_aura_int2_lookup[1] = cus_aura_int2_lookup[5] = cus_aura_int2_lookup[21] = cus_aura_int2_lookup[23] = 1; 
@@ -1071,6 +1072,7 @@ PUBLIC void PreBakeSetup(size_t)
 	aur_bpe_map[52] = 281;
 	aur_bpe_map[53] = 302;
 	aur_bpe_map[57] = aur_bpe_map[58] = aur_bpe_map[59] = aur_bpe_map[60] = 320;
+	aur_bpe_map[61] = 340;
 	aur_bpe_flag1[39] = aur_bpe_flag1[52] = aur_bpe_flag1[53] = true;
 	aur_bpe_flag2[36] = aur_bpe_flag2[39] = aur_bpe_flag2[52] = aur_bpe_flag2[53] = true;
 	// Original Golden Freezer Skin behaviour
@@ -1504,7 +1506,7 @@ PUBLIC void CusAuraPatchTeleport(uint8_t *buf)
 		exit(-1);
 	}
 	
-	PatchUtils::Write64(ret_addr2, (uint64_t)(buf+0x999)); // buf+0x999 -> address return for no teleport   
+	PatchUtils::Write64(ret_addr2, (uint64_t)(buf+0x989)); // buf+0x989 -> address return for no teleport   
 }
 
 PUBLIC uint32_t Behaviour13(Battle_Mob *pthis)

--- a/chara_patch_asm.S
+++ b/chara_patch_asm.S
@@ -22,7 +22,7 @@ ret1:
 	.def	GetCABehaviour11;	.scl	2;	.type	32;	.endef
 	
 GetCABehaviour11:	
-	mov edx, [rbx+0x224C]
+	mov edx, [rbx+0x225C]
 	# AFTER HERE, EDX MUST NOT BE OVERWRITTEN OR IT WILL OVERWRITE BEHAVIOUR10
 	cmp edx, 8191
 	ja orig2
@@ -53,7 +53,7 @@ ret2:
 	
 ForceTeleport:
 
-	mov ecx, [rbx+0x224C]
+	mov ecx, [rbx+0x225C]
 	cmp ecx, 8191
 	ja default_teleport
 	lea rdx, force_teleport[rip]
@@ -72,7 +72,7 @@ ForceTeleport:
 	
 default_teleport:
 
-	cmp  [rbx+0x224C], eax
+	cmp  [rbx+0x225C], eax
 	jne no_teleport
 
 teleport:	
@@ -166,7 +166,7 @@ if_not_bpe:
 	.def	GetCABehaviour64;	.scl	2;	.type	32;	.endef
 	
 GetCABehaviour64:
-	mov eax, [rbx+0x224C]
+	mov eax, [rbx+0x225C]
 	cmp eax, 8191
 	ja orig3
 	lea rcx, cus_aura_bh64_lookup[rip]

--- a/game_defs.h
+++ b/game_defs.h
@@ -125,9 +125,9 @@ struct Battle_Mob
 	Battle_Command *battle_command; // 04D8
 	uint8_t unk_4E0[0x2094-0x4E0]; 
 	int32_t loaded_var; // 2094 ; if >= 0, char is loaded
-	uint8_t unk_2088[0x2248-0x2098];
-	uint32_t trans_partset; // 2248
-	int32_t trans_control; // 224C
+	uint8_t unk_2088[0x2258-0x2098];
+	uint32_t trans_partset; // 2258
+	int32_t trans_control; // 225C
 	// ...
 	// ...
 	
@@ -180,8 +180,8 @@ CHECK_FIELD_OFFSET(Battle_Mob, unk_interface_var, 0x3B0);
 CHECK_FIELD_OFFSET(Battle_Mob, common_chara, 0x4C8);
 CHECK_FIELD_OFFSET(Battle_Mob, battle_command, 0x4D8);
 CHECK_FIELD_OFFSET(Battle_Mob, loaded_var, 0x2094);
-CHECK_FIELD_OFFSET(Battle_Mob, trans_partset, 0x2248);
-CHECK_FIELD_OFFSET(Battle_Mob, trans_control, 0x224C);
+CHECK_FIELD_OFFSET(Battle_Mob, trans_partset, 0x2258);
+CHECK_FIELD_OFFSET(Battle_Mob, trans_control, 0x225C);
 
 // 1.20. size 0x180 -> 0x190
 // 1.21 size 0x190 -> 0x1A0

--- a/xv2patcher.h
+++ b/xv2patcher.h
@@ -16,13 +16,13 @@
 
 #define CONTENT_ROOT	"../"
 
-#define MINIMUM_GAME_VERSION	1.23f
+#define MINIMUM_GAME_VERSION	1.24f
 
 #define SLOTS_FILE         		"data/XV2P_SLOTS.x2s"
 #define SLOTS_FILE_STAGE		"data/XV2P_SLOTS_STAGE.x2s"
 #define SLOTS_FILE_STAGE_LOCAL	"data/XV2P_SLOTS_STAGE_LOCAL.x2s"
 
-#define XV2_PATCHER_VERSION	"4.4"
+#define XV2_PATCHER_VERSION	"4.5"
 
 typedef void (* IGGYSetTraceCallbackType)(void *callback, void *param);
 typedef void (* IGGYSetWarningCallbackType)(void *callback, void *param);


### PR DESCRIPTION
This is a non-standard PR, as it's something I'd like to keep working on, if incomplete.
I've updated all the outdated patterns and rewrote the patches, as I only acquired the game recently on PC and I've yet to make a save file and play it (only played it on the PS4 some years ago).
I'm interested in getting this working on the latest version, so it may be played online with other people who are using the patcher at the very least.
I could also code an excessive_air_contamination bypass so people could load their cosmetic mods and play with everyone online (I did extension spoofing for DBFZ with a kernel driver, present in: https://github.com/HAWGT/DBFZ-MOD-ENABLER - no bans to date for more than 3 years).
I may require some additional guidance on what's left, I noticed a big constant list in "chara_patch.cpp", I'm left without a clue on how to find them.